### PR TITLE
Remove commands from headings

### DIFF
--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -5,7 +5,4 @@ sort_by = "date"
 template = "posts.html"
 
 insert_anchor_links = "heading"
-
-[extra]
-command = "ls Posts"
 +++

--- a/sass/parts/_header.scss
+++ b/sass/parts/_header.scss
@@ -7,31 +7,10 @@
         line-height: 100%;
         margin: 0;
         font-weight: normal;
-        // To align with the blinking cursor from the ::after
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: 10px 2px;
 
         // Remove the default # before the element
         &::before {
             content: none;
-        }
-
-        // Add a blinking cursor after the element
-        // Modified version of https://www.amitmerchant.com/simple-blinking-cursor-animation-using-css/
-        @keyframes cursor-blink {
-            0% {
-                opacity: 0;
-            }
-        }
-        &.with-cursor::after {
-            content: "";
-            width: 15px;
-            height: 1em;
-            background: var(--primary-color);
-            display: inline-block;
-            animation: cursor-blink 1.5s steps(2) infinite;
         }
     }
 }

--- a/templates/index.de.html
+++ b/templates/index.de.html
@@ -4,9 +4,9 @@
     <main>
         <article>
             <section class="body">
-                {{post_macros::page_header(title="motd")}}
+                {{ post_macros::page_header(title=section.title) }}
 
-                <b>Salut! Hi! Hallo! 👋</b>
+                <h2>Salut! Hi! Hallo! 👋</h2>
 
                 <p>
                     Ich bin Dany, ein Québécois der im schönen

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,9 +4,9 @@
     <main>
         <article>
             <section class="body">
-                {{post_macros::page_header(title="motd")}}
+                {{ post_macros::page_header(title=section.title) }}
 
-                <b>Salut! Hi! Hallo! 👋</b>
+                <h2>Salut! Hi! Hallo! 👋</h2>
 
                 <p>
                     I am Dany, a Québécois living in the beautiful city of

--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -85,12 +85,8 @@
     {% endif -%}
 {% endmacro tags %}
 
-{% macro page_header(title, mimick_shell=true) %}
+{% macro page_header(title) %}
     <div class="page-header">
-        {%- if mimick_shell %}
-        <h1 class="with-cursor"><span style="margin-right: 5px;">[dany@~]$ </span><span>{{ title }}</span></h1>
-        {% else %}
-            <h1>{{ title }}</h1>
-        {% endif -%}
+        <h1>{{ title }}</h1>
     </div>
 {% endmacro page_header %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -12,7 +12,7 @@
                 </div>
             {% endif %}
 
-            {{ post_macros::page_header(title=page.title,mimick_shell=false) }}
+            {{ post_macros::page_header(title=page.title) }}
 
                 <div class="meta">
                     {% if page.date %}

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -14,7 +14,7 @@
     {% endif -%}
 
     {% block title %}
-        {{ post_macros::page_header(title=section.extra.command) }}
+        {{ post_macros::page_header(title=section.title) }}
     {% endblock title %}
 
     {% block post_list %}


### PR DESCRIPTION
This is much more SEO-friendly, while being clearer for all readers, not only engineers.